### PR TITLE
Add campaign manager with persistence

### DIFF
--- a/src/foodops_pro/domain/__init__.py
+++ b/src/foodops_pro/domain/__init__.py
@@ -12,6 +12,7 @@ from .stock import StockLot
 from .restaurant import Restaurant, RestaurantType
 from .employee import Employee, EmployeeContract, EmployeePosition
 from .scenario import Scenario, MarketSegment
+from .campaign import CampaignManager
 
 __all__ = [
     "Ingredient",
@@ -26,4 +27,5 @@ __all__ = [
     "EmployeePosition",
     "Scenario",
     "MarketSegment",
+    "CampaignManager",
 ]

--- a/src/foodops_pro/domain/campaign.py
+++ b/src/foodops_pro/domain/campaign.py
@@ -1,0 +1,57 @@
+"""Gestionnaire de campagne pour enchaîner plusieurs scénarios."""
+
+from dataclasses import dataclass, field
+from typing import List
+
+from .scenario import Scenario
+from ..io.persistence import CampaignPersistence, CampaignProgress
+
+
+@dataclass
+class CampaignManager:
+    """Gère une campagne composée de plusieurs scénarios.
+
+    Attributes:
+        name: Nom de la campagne.
+        scenarios: Liste ordonnée des scénarios.
+        persistence: Gestionnaire de persistance pour sauvegarder la progression.
+    """
+
+    name: str
+    scenarios: List[Scenario]
+    persistence: CampaignPersistence
+    progress: CampaignProgress = field(init=False)
+
+    def __post_init__(self) -> None:
+        """Charge ou initialise la progression de la campagne."""
+        scenario_names = [s.name for s in self.scenarios]
+        loaded = self.persistence.load_progress(self.name)
+        if loaded and loaded.scenario_names == scenario_names:
+            self.progress = loaded
+        else:
+            self.progress = CampaignProgress(
+                campaign_name=self.name,
+                scenario_names=scenario_names,
+                current_index=0,
+            )
+            self.persistence.save_progress(self.progress)
+
+    def current_scenario(self) -> Scenario:
+        """Retourne le scénario actuel."""
+        return self.scenarios[self.progress.current_index]
+
+    def advance(self) -> bool:
+        """Avance au scénario suivant si possible et sauvegarde la progression.
+
+        Returns:
+            True si le scénario a changé, False si la campagne est terminée.
+        """
+        if self.progress.current_index < len(self.scenarios) - 1:
+            self.progress.current_index += 1
+            self.persistence.save_progress(self.progress)
+            return True
+        return False
+
+    def is_completed(self) -> bool:
+        """Indique si tous les scénarios de la campagne ont été terminés."""
+        return self.progress.current_index >= len(self.scenarios) - 1

--- a/tests/test_campaign.py
+++ b/tests/test_campaign.py
@@ -1,0 +1,43 @@
+"""Tests du gestionnaire de campagne."""
+
+from decimal import Decimal
+from pathlib import Path
+
+from src.foodops_pro.domain.scenario import Scenario, MarketSegment
+from src.foodops_pro.domain.restaurant import RestaurantType
+from src.foodops_pro.domain.campaign import CampaignManager
+from src.foodops_pro.io.persistence import CampaignPersistence
+
+
+def _make_scenario(name: str) -> Scenario:
+    segment = MarketSegment(
+        name="Unique",
+        share=Decimal("1.0"),
+        budget=Decimal("10"),
+        type_affinity={RestaurantType.CLASSIC: Decimal("1.0")},
+    )
+    return Scenario(
+        name=name,
+        description="",
+        turns=1,
+        base_demand=100,
+        demand_noise=Decimal("0"),
+        segments=[segment],
+    )
+
+
+def test_campaign_progress_persistence(tmp_path: Path) -> None:
+    """La progression doit être sauvegardée et restaurée."""
+    scenarios = [_make_scenario("S1"), _make_scenario("S2")]
+    persistence = CampaignPersistence(save_directory=tmp_path)
+
+    manager = CampaignManager("camp", scenarios, persistence)
+    assert manager.current_scenario().name == "S1"
+
+    manager.advance()
+    assert manager.current_scenario().name == "S2"
+
+    # Rechargement pour vérifier la persistance
+    manager2 = CampaignManager("camp", scenarios, persistence)
+    assert manager2.current_scenario().name == "S2"
+    assert manager2.is_completed()


### PR DESCRIPTION
## Summary
- add CampaignManager to chain scenarios
- persist campaign progress via CampaignPersistence
- test campaign progress saving and loading

## Testing
- `pytest -q` *(fails: ImportError while importing tests/test_complete.py: cannot import name 'Position')*
- `pytest tests/test_campaign.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5d4be38e08333bc305e58b44a73e3