### PR TITLE
feat: scaffold Next.js prototype with tRPC and Prisma schema

### DIFF
--- a/foodops-web/next-env.d.ts
+++ b/foodops-web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/foodops-web/next.config.mjs
+++ b/foodops-web/next.config.mjs
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true
+  }
+};
+export default nextConfig;

--- a/foodops-web/package.json
+++ b/foodops-web/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "foodops-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "echo \"no tests implemented\""
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "@trpc/server": "10.45.0",
+    "@trpc/client": "10.45.0",
+    "zod": "3.23.3",
+    "@prisma/client": "5.16.1"
+  },
+  "devDependencies": {
+    "typescript": "5.4.5",
+    "ts-node": "10.9.2",
+    "@types/react": "18.2.66",
+    "@types/node": "20.11.30",
+    "prisma": "5.16.1"
+  }
+}

--- a/foodops-web/prisma/schema.prisma
+++ b/foodops-web/prisma/schema.prisma
@@ -1,0 +1,22 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+model Restaurant {
+  id           String  @id @default(uuid())
+  name         String
+  type         String
+  capacityBase Int
+  cash         Decimal @default(0)
+}
+
+model Scenario {
+  id          String @id
+  name        String
+  description String?
+}

--- a/foodops-web/src/app/api/trpc/[trpc]/route.ts
+++ b/foodops-web/src/app/api/trpc/[trpc]/route.ts
@@ -1,0 +1,12 @@
+import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
+import { appRouter } from '@/server/routers/root';
+
+const handler = (req: Request) =>
+  fetchRequestHandler({
+    endpoint: '/api/trpc',
+    req,
+    router: appRouter,
+    createContext: () => ({})
+  });
+
+export { handler as GET, handler as POST };

--- a/foodops-web/src/app/page.tsx
+++ b/foodops-web/src/app/page.tsx
@@ -1,0 +1,8 @@
+export default function HomePage() {
+  return (
+    <main className="p-4">
+      <h1 className="text-xl font-bold">FoodOps Web Prototype</h1>
+      <p>Bienvenue sur le prototype Next.js de FoodOps Pro.</p>
+    </main>
+  );
+}

--- a/foodops-web/src/app/scenarios/page.tsx
+++ b/foodops-web/src/app/scenarios/page.tsx
@@ -1,0 +1,20 @@
+async function getScenarios() {
+  const res = await fetch('http://localhost:3000/api/trpc/scenarios', {
+    headers: {
+      'content-type': 'application/json',
+    },
+    cache: 'no-store'
+  });
+  const json = await res.json();
+  return json.result?.data?.json ?? [];
+}
+
+export default async function ScenariosPage() {
+  const scenarios = await getScenarios();
+  return (
+    <main className="p-4">
+      <h1 className="text-xl font-bold mb-2">Scénarios</h1>
+      <pre>{JSON.stringify(scenarios, null, 2)}</pre>
+    </main>
+  );
+}

--- a/foodops-web/src/data/scenarios.json
+++ b/foodops-web/src/data/scenarios.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "demo",
+    "name": "Scénario Démonstration",
+    "description": "Configuration simplifiée pour démonstrations rapides"
+  },
+  {
+    "id": "standard",
+    "name": "Scénario Standard",
+    "description": "Configuration équilibrée pour apprentissage général"
+  }
+]

--- a/foodops-web/src/scripts/sync-scenarios.ts
+++ b/foodops-web/src/scripts/sync-scenarios.ts
@@ -1,0 +1,17 @@
+import fs from 'fs';
+import path from 'path';
+import yaml from 'yaml';
+
+const scenariosDir = path.join(__dirname, '..', '..', '..', 'scenarios');
+const output = path.join(__dirname, '..', 'data');
+fs.mkdirSync(output, { recursive: true });
+
+const files = fs.readdirSync(scenariosDir).filter(f => f.endsWith('.yaml'));
+const scenarios = files.map(file => {
+  const raw = fs.readFileSync(path.join(scenariosDir, file), 'utf8');
+  const data = yaml.parse(raw);
+  return { id: path.basename(file, '.yaml'), ...data };
+});
+
+fs.writeFileSync(path.join(output, 'scenarios.json'), JSON.stringify(scenarios, null, 2));
+console.log(`Synchronised ${scenarios.length} scenarios`);

--- a/foodops-web/src/server/routers/root.ts
+++ b/foodops-web/src/server/routers/root.ts
@@ -1,0 +1,21 @@
+import { router, procedure } from '../trpc';
+import fs from 'fs';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+export const appRouter = router({
+  hello: procedure.query(() => {
+    return { message: 'Bienvenue sur tRPC' };
+  }),
+  pythonPing: procedure.query(() => {
+    const result = spawnSync('python', ['-c', 'print("pong")']);
+    return { message: result.stdout.toString().trim() };
+  }),
+  scenarios: procedure.query(() => {
+    const file = path.join(process.cwd(), 'src', 'data', 'scenarios.json');
+    const raw = fs.readFileSync(file, 'utf8');
+    return JSON.parse(raw);
+  })
+});
+
+export type AppRouter = typeof appRouter;

--- a/foodops-web/src/server/trpc.ts
+++ b/foodops-web/src/server/trpc.ts
@@ -1,0 +1,6 @@
+import { initTRPC } from '@trpc/server';
+
+const t = initTRPC.create();
+
+export const router = t.router;
+export const procedure = t.procedure;

--- a/foodops-web/src/types/index.ts
+++ b/foodops-web/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from './restaurant';
+export * from './scenario';

--- a/foodops-web/src/types/restaurant.ts
+++ b/foodops-web/src/types/restaurant.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export enum RestaurantType {
+  FAST = 'fast',
+  CLASSIC = 'classic',
+  GASTRONOMIQUE = 'gastronomique',
+  BRASSERIE = 'brasserie',
+}
+
+export const RestaurantSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: z.nativeEnum(RestaurantType),
+  capacityBase: z.number().int().positive(),
+  speedService: z.number().positive(),
+  cash: z.number().optional(),
+});
+
+export type Restaurant = z.infer<typeof RestaurantSchema>;

--- a/foodops-web/src/types/scenario.ts
+++ b/foodops-web/src/types/scenario.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const ScenarioSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+});
+
+export type Scenario = z.infer<typeof ScenarioSchema>;

--- a/foodops-web/tsconfig.json
+++ b/foodops-web/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold `foodops-web` Next.js app with TypeScript
- add Prisma schema and Zod types for Restaurant and Scenario
- expose tRPC router including python bridge and scenario listing

## Testing
- `npm test`
- `npm run build` *(fails: next not found)*
- `npm run lint` *(fails: next not found)*
- `npx prisma generate` *(fails: 403 Forbidden)*
- `npx ts-node src/scripts/sync-scenarios.ts` *(fails: 403 Forbidden)*
- `npx tsc --noEmit` *(fails: missing modules)*
- `pytest` *(fails: ImportError: cannot import name 'Position')*

------
https://chatgpt.com/codex/tasks/task_e_68a5d4c047d48333be4fb334407d89d0