### PR TITLE
Add simple TCP session server with scoreboard and observer channel

### DIFF
--- a/src/foodops_pro/network/__init__.py
+++ b/src/foodops_pro/network/__init__.py
@@ -1,0 +1,5 @@
+"""Networking utilities for FoodOps Pro."""
+
+from .session_server import SessionServer
+
+__all__ = ["SessionServer"]

--- a/src/foodops_pro/network/session_server.py
+++ b/src/foodops_pro/network/session_server.py
@@ -1,0 +1,114 @@
+"""Asynchronous TCP session server with scoreboard and observer support."""
+
+import asyncio
+import json
+from typing import Dict, List
+
+
+class SessionServer:
+    """Host a multiplayer session.
+
+    Players and observers connect via a simple newline-delimited JSON protocol. Each
+    client must send an initial JSON object declaring its ``role`` (``player`` or
+    ``observer``) and a ``name``. Players can then send decisions or score updates
+    which are broadcast to all observers.
+    """
+
+    def __init__(self, host: str = "127.0.0.1", port: int = 8765):
+        self.host = host
+        self.port = port
+        self.players: Dict[str, asyncio.StreamWriter] = {}
+        self.observers: List[asyncio.StreamWriter] = []
+        self.scores: Dict[str, float] = {}
+        self.decisions: Dict[str, List[str]] = {}
+        self._server: asyncio.AbstractServer | None = None
+
+    async def _send(self, writer: asyncio.StreamWriter, message: Dict[str, object]) -> None:
+        writer.write((json.dumps(message) + "\n").encode())
+        await writer.drain()
+
+    async def _handle_client(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            raw = await reader.readline()
+            data = json.loads(raw.decode().strip())
+        except Exception:
+            writer.close()
+            await writer.wait_closed()
+            return
+
+        role = data.get("role")
+        name = data.get("name", "")
+        if role == "player":
+            self.players[name] = writer
+            self.scores.setdefault(name, 0.0)
+            self.decisions.setdefault(name, [])
+            await self._send(writer, {"type": "joined", "role": "player"})
+        elif role == "observer":
+            self.observers.append(writer)
+            await self._send(writer, {"type": "joined", "role": "observer"})
+        else:
+            writer.close()
+            await writer.wait_closed()
+            return
+
+        try:
+            while not reader.at_eof():
+                raw = await reader.readline()
+                if not raw:
+                    break
+                payload = json.loads(raw.decode().strip())
+                if role == "player" and payload.get("type") == "decision":
+                    decision = payload.get("decision")
+                    self.decisions[name].append(decision)
+                    await self.broadcast({
+                        "type": "decision",
+                        "player": name,
+                        "decision": decision,
+                    })
+                elif role == "player" and payload.get("type") == "score":
+                    score = float(payload.get("score", 0))
+                    self.scores[name] = score
+                    await self.broadcast({"type": "scoreboard", "scores": self.scores})
+        finally:
+            if role == "player":
+                self.players.pop(name, None)
+                self.scores.pop(name, None)
+                self.decisions.pop(name, None)
+            elif role == "observer":
+                if writer in self.observers:
+                    self.observers.remove(writer)
+            writer.close()
+            await writer.wait_closed()
+
+    async def broadcast(self, message: Dict[str, object]) -> None:
+        for obs in list(self.observers):
+            try:
+                await self._send(obs, message)
+            except Exception:
+                if obs in self.observers:
+                    self.observers.remove(obs)
+
+    async def start(self) -> asyncio.AbstractServer:
+        """Start the TCP server."""
+        self._server = await asyncio.start_server(self._handle_client, self.host, self.port)
+        return self._server
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+
+async def main(host: str = "127.0.0.1", port: int = 8765) -> None:
+    server = SessionServer(host, port)
+    srv = await server.start()
+    async with srv:
+        await srv.serve_forever()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/tests/test_session_server.py
+++ b/tests/test_session_server.py
@@ -1,0 +1,47 @@
+import asyncio
+import importlib.util
+import json
+import pathlib
+
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "session_server", pathlib.Path("src/foodops_pro/network/session_server.py")
+)
+session_server = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(session_server)
+SessionServer = session_server.SessionServer
+
+
+@pytest.mark.asyncio
+async def test_scoreboard_and_observer_receives_updates():
+    server = SessionServer()
+    srv = await server.start()
+    async with srv:
+        # connect observer
+        reader_o, writer_o = await asyncio.open_connection("127.0.0.1", 8765)
+        writer_o.write(json.dumps({"role": "observer", "name": "trainer"}).encode() + b"\n")
+        await writer_o.drain()
+        msg = await reader_o.readline()
+        assert json.loads(msg.decode())["role"] == "observer"
+
+        # connect player
+        reader_p, writer_p = await asyncio.open_connection("127.0.0.1", 8765)
+        writer_p.write(json.dumps({"role": "player", "name": "p1"}).encode() + b"\n")
+        await writer_p.drain()
+        msg = await reader_p.readline()
+        assert json.loads(msg.decode())["role"] == "player"
+
+        # send score update
+        writer_p.write(json.dumps({"type": "score", "score": 10}).encode() + b"\n")
+        await writer_p.drain()
+        update = await reader_o.readline()
+        data = json.loads(update.decode())
+        assert data["type"] == "scoreboard"
+        assert data["scores"]["p1"] == 10
+
+        writer_p.close()
+        await writer_p.wait_closed()
+        writer_o.close()
+        await writer_o.wait_closed()
+    await server.stop()


### PR DESCRIPTION
## Summary
- add async TCP SessionServer supporting multiple players and observers
- broadcast decisions and scores to observers for a shared scoreboard
- include async test demonstrating scoreboard updates

## Testing
- `python -m pytest tests/ -v` *(fails: SyntaxError in existing market module)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b224c8fc833399dbac72a9543a19