### PR TITLE
Add pedagogical learning path documentation

### DIFF
--- a/docs/parcours_apprentissage.md
+++ b/docs/parcours_apprentissage.md
@@ -1,0 +1,40 @@
+# Parcours d'apprentissage et dossier pédagogique
+
+Ce document décrit un parcours d'apprentissage basé sur FoodOps Pro, avec modules, exercices pratiques, suivi de progression et outils pour les formateurs.
+
+## 1. Parcours d'apprentissage modulaire
+
+Chaque module introduit une notion clé et propose un exercice pratique :
+
+| Module | Notion clé | Exercice pratique |
+|--------|------------|------------------|
+| 1. Menu engineering | Calcul des coûts matière et optimisation du menu | Ajuster les prix d'un menu de base pour atteindre une marge cible dans le jeu |
+| 2. Achats & stocks | Gestion FEFO et calcul des besoins | Planifier les commandes d'ingrédients pour éviter les ruptures tout en minimisant les pertes |
+| 3. Ressources humaines | Planification et coût du personnel | Dimensionner l'équipe pour différents niveaux d'activité et analyser l'impact financier |
+| 4. Finance & comptabilité | Compte de résultat simplifié | Interpréter le rapport financier après plusieurs tours de jeu |
+
+Les modules peuvent être enchaînés ou utilisés de manière indépendante selon les objectifs pédagogiques.
+
+## 2. Rapports de progression et badges
+
+- **Rapport de progression** : après chaque session, exporter les KPIs clés (trésorerie, coût matière, taux d'utilisation, etc.) pour suivre l'évolution des étudiants.
+- **Badges** : attribuer un badge lorsque certains objectifs sont atteints :
+  - *Maître des coûts* : atteindre un coût matière < 30 % pendant 3 tours consécutifs.
+  - *Gestionnaire averti* : clôturer la partie avec une trésorerie positive et un taux d'utilisation > 80 %.
+  - *Stratège RH* : maintenir la satisfaction du personnel > 70 % pendant toute la partie.
+
+Ces badges peuvent être remis manuellement par le formateur ou générés via un script d'analyse des rapports exportés.
+
+## 3. Dossier pédagogique pour les formateurs
+
+Le dossier pédagogique contient :
+
+- **Fiches de cours** : résumé de chaque notion clé, objectifs et ressources complémentaires.
+- **Suggestions d'animation** :
+  - Démarrer chaque module par un bref exposé théorique (10 min)
+  - Lancer une session de jeu dédiée à l'exercice pratique (20-30 min)
+  - Organiser un débriefing collectif avec analyse des résultats (15 min)
+- **Évaluation** : utiliser les rapports de progression et les badges pour évaluer la maîtrise des concepts.
+
+Ce support est conçu pour être adaptable à différents formats (présentiel, distanciel, ateliers courts ou cursus longs).
+


### PR DESCRIPTION
## Summary
- Document modular learning path with exercises for FoodOps Pro
- Describe progress reports and badge milestones
- Provide trainer tips and evaluation guidance

## Testing
- `python -m pytest` *(fails: SyntaxError in src/foodops_pro/core/market.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b224a3c08333ba36497764002fed