### PR TITLE
Add supplier order limits, staff planner, and review mechanics

### DIFF
--- a/src/foodops_pro/core/market.py
+++ b/src/foodops_pro/core/market.py
@@ -421,53 +421,6 @@ class MarketEngine:
         except Exception:
             return Decimal('1.00')
 
-            restaurant: Restaurant évalué
-            segment: Segment de marché
-
-        Returns:
-            Facteur qualité (0.5 à 2.0)
-        """
-        # NOUVEAU: Utilisation du score de qualité du restaurant
-        quality_score = restaurant.get_overall_quality_score()
-
-        # Conversion du score qualité (1-5) en facteur d'attractivité
-        if quality_score <= Decimal("1.5"):
-            base_factor = Decimal("0.70")  # -30%
-        elif quality_score <= Decimal("2.5"):
-            base_factor = Decimal("1.00")  # Neutre
-        elif quality_score <= Decimal("3.5"):
-            base_factor = Decimal("1.20")  # +20%
-        elif quality_score <= Decimal("4.5"):
-            base_factor = Decimal("1.40")  # +40%
-        else:
-            base_factor = Decimal("1.60")  # +60%
-
-        # NOUVEAU: Sensibilité à la qualité par segment
-        segment_name = segment.name.lower()
-        quality_sensitivity = Decimal("1.0")
-
-        if "student" in segment_name or "étudiant" in segment_name:
-            quality_sensitivity = Decimal("0.6")  # Moins sensibles
-        elif "foodie" in segment_name or "gourmet" in segment_name:
-            quality_sensitivity = Decimal("1.4")  # Très sensibles
-        elif "family" in segment_name or "famille" in segment_name:
-            quality_sensitivity = Decimal("1.0")  # Sensibilité normale
-
-        # Ajustement selon la sensibilité du segment
-        if base_factor > Decimal("1.0"):
-            bonus = (base_factor - Decimal("1.0")) * quality_sensitivity
-            final_factor = Decimal("1.0") + bonus
-        else:
-            malus = (Decimal("1.0") - base_factor) * quality_sensitivity
-            final_factor = Decimal("1.0") - malus
-        # NOUVEAU: Impact de la réputation
-        reputation_factor = restaurant.reputation / Decimal("10")  # 0-1
-        reputation_bonus = (reputation_factor - Decimal("0.5")) * Decimal("0.2")  # ±10%
-        final_factor += reputation_bonus
-        return max(Decimal("0.5"), min(Decimal("2.0"), final_factor))
-
-        return max(Decimal("0.5"), min(Decimal("2.0"), final_factor))
-
     def _get_season_name(self, month: int) -> str:
         """Retourne le nom de la saison selon le mois."""
         if month in [12, 1, 2]:

--- a/src/foodops_pro/core/staff_planner.py
+++ b/src/foodops_pro/core/staff_planner.py
@@ -1,0 +1,42 @@
+"""Simple staff scheduling planner for FoodOps Pro."""
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import List
+
+from ..domain.employee import Employee
+
+
+@dataclass
+class Shift:
+    """Represents a work shift for an employee."""
+
+    employee: Employee
+    hours: Decimal
+
+
+@dataclass
+class StaffScheduleResult:
+    """Outcome of schedule evaluation."""
+
+    total_cost: Decimal
+    satisfaction: Decimal
+
+
+class StaffPlanner:
+    """Evaluates staff schedules for cost and satisfaction."""
+
+    def evaluate(self, required_hours: Decimal, shifts: List[Shift]) -> StaffScheduleResult:
+        """Compute total cost and satisfaction for a schedule.
+
+        Args:
+            required_hours: Hours needed to fully satisfy demand.
+            shifts: List of planned shifts.
+        """
+        scheduled = sum(shift.hours for shift in shifts)
+        if required_hours > 0:
+            satisfaction = min(Decimal("1"), Decimal(scheduled) / required_hours)
+        else:
+            satisfaction = Decimal("1")
+        total_cost = sum(shift.employee.hourly_rate * shift.hours for shift in shifts)
+        return StaffScheduleResult(total_cost=total_cost, satisfaction=satisfaction)

--- a/src/foodops_pro/domain/review.py
+++ b/src/foodops_pro/domain/review.py
@@ -1,0 +1,32 @@
+"""Online review mechanics affecting restaurant reputation."""
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import List, Optional
+
+from .restaurant import Restaurant
+
+
+@dataclass
+class Review:
+    rating: Decimal  # 0-5 stars
+    comment: Optional[str] = None
+
+
+@dataclass
+class ReviewManager:
+    reviews: List[Review] = field(default_factory=list)
+
+    def add_review(self, restaurant: Restaurant, rating: Decimal, comment: str | None = None) -> Decimal:
+        """Add a review and update restaurant reputation.
+
+        The rating is on a 0-5 scale and mapped to the restaurant reputation (0-10).
+        A simple moving average (80% previous reputation, 20% new rating) is used.
+        Returns the updated reputation.
+        """
+        review = Review(rating=rating, comment=comment)
+        self.reviews.append(review)
+        mapped = rating * Decimal("2")  # convert 0-5 -> 0-10
+        restaurant.reputation = (restaurant.reputation * Decimal("0.8") + mapped * Decimal("0.2"))
+        restaurant.customer_satisfaction_history.append(mapped)
+        return restaurant.reputation

--- a/src/foodops_pro/domain/supplier.py
+++ b/src/foodops_pro/domain/supplier.py
@@ -3,6 +3,7 @@ Modèle des fournisseurs pour FoodOps Pro.
 """
 
 from dataclasses import dataclass
+from datetime import date, timedelta
 from typing import Dict, Optional
 from decimal import Decimal
 
@@ -18,6 +19,8 @@ class Supplier:
         reliability: Fiabilité de livraison (0.0-1.0)
         lead_time_days: Délai de livraison en jours
         min_order_value: Montant minimum de commande (MOQ)
+        min_order_quantity: Quantité minimale par commande
+        max_order_quantity: Quantité maximale par commande
         shipping_cost: Frais de port fixes
         payment_terms_days: Délai de paiement en jours
         discount_threshold: Seuil pour remise quantité
@@ -30,6 +33,8 @@ class Supplier:
     lead_time_days: int
     min_order_value: Decimal
     shipping_cost: Decimal
+    min_order_quantity: Optional[Decimal] = None
+    max_order_quantity: Optional[Decimal] = None
     payment_terms_days: int = 30
     discount_threshold: Optional[Decimal] = None
     discount_rate: Optional[Decimal] = None
@@ -48,6 +53,20 @@ class Supplier:
             raise ValueError(
                 f"Les frais de port doivent être positifs: {self.shipping_cost}"
             )
+        if self.min_order_quantity is not None and self.min_order_quantity < 0:
+            raise ValueError(
+                f"La quantité minimale doit être positive: {self.min_order_quantity}"
+            )
+        if self.max_order_quantity is not None and self.max_order_quantity <= 0:
+            raise ValueError(
+                f"La quantité maximale doit être positive: {self.max_order_quantity}"
+            )
+        if (
+            self.min_order_quantity is not None
+            and self.max_order_quantity is not None
+            and self.min_order_quantity > self.max_order_quantity
+        ):
+            raise ValueError("La quantité minimale ne peut dépasser la quantité maximale")
         if self.payment_terms_days < 0:
             raise ValueError(
                 f"Le délai de paiement doit être positif: {self.payment_terms_days}"
@@ -63,12 +82,13 @@ class Supplier:
                     f"Le taux de remise doit être entre 0 et 1: {self.discount_rate}"
                 )
 
-    def calculate_total_cost(self, order_value_ht: Decimal) -> Decimal:
+    def calculate_total_cost(self, order_value_ht: Decimal, quantity: Decimal) -> Decimal:
         """
         Calcule le coût total d'une commande incluant frais de port et remises.
 
         Args:
             order_value_ht: Valeur HT de la commande
+            quantity: Quantité totale commandée
 
         Returns:
             Coût total HT
@@ -76,6 +96,14 @@ class Supplier:
         if order_value_ht < self.min_order_value:
             raise ValueError(
                 f"Commande {order_value_ht} inférieure au MOQ {self.min_order_value}"
+            )
+        if self.min_order_quantity is not None and quantity < self.min_order_quantity:
+            raise ValueError(
+                f"Quantité {quantity} inférieure au minimum {self.min_order_quantity}"
+            )
+        if self.max_order_quantity is not None and quantity > self.max_order_quantity:
+            raise ValueError(
+                f"Quantité {quantity} supérieure au maximum {self.max_order_quantity}"
             )
 
         # Application de la remise si applicable
@@ -89,17 +117,28 @@ class Supplier:
 
         return discounted_value + self.shipping_cost
 
-    def can_fulfill_order(self, order_value_ht: Decimal) -> bool:
+    def can_fulfill_order(self, order_value_ht: Decimal, quantity: Decimal) -> bool:
         """
         Vérifie si le fournisseur peut traiter une commande.
 
         Args:
             order_value_ht: Valeur HT de la commande
+            quantity: Quantité totale
 
         Returns:
             True si la commande peut être traitée
         """
-        return order_value_ht >= self.min_order_value
+        if order_value_ht < self.min_order_value:
+            return False
+        if self.min_order_quantity is not None and quantity < self.min_order_quantity:
+            return False
+        if self.max_order_quantity is not None and quantity > self.max_order_quantity:
+            return False
+        return True
+
+    def get_expected_delivery_date(self, order_date: date) -> date:
+        """Calcule la date de livraison prévue en fonction du délai."""
+        return order_date + timedelta(days=self.lead_time_days)
 
     def get_delivery_risk(self) -> str:
         """

--- a/tests/test_reviews_market.py
+++ b/tests/test_reviews_market.py
@@ -1,0 +1,53 @@
+from decimal import Decimal
+
+from src.foodops_pro.domain.restaurant import Restaurant, RestaurantType
+from src.foodops_pro.domain.scenario import Scenario, MarketSegment
+from src.foodops_pro.core.market import MarketEngine
+from src.foodops_pro.domain.review import ReviewManager
+
+
+def test_reviews_influence_demand():
+    segment = MarketSegment(
+        name="test",
+        share=Decimal("1"),
+        budget=Decimal("10"),
+        type_affinity={RestaurantType.FAST: Decimal("1")},
+    )
+    scenario = Scenario(
+        name="s",
+        description="",
+        turns=1,
+        base_demand=100,
+        demand_noise=Decimal("0"),
+        segments=[segment],
+        random_seed=42,
+    )
+    market = MarketEngine(scenario, random_seed=42)
+    r1 = Restaurant(
+        id="r1",
+        name="A",
+        type=RestaurantType.FAST,
+        capacity_base=100,
+        speed_service=Decimal("1"),
+        menu={"r": Decimal("10")},
+        active_recipes=["r"],
+    )
+    r2 = Restaurant(
+        id="r2",
+        name="B",
+        type=RestaurantType.FAST,
+        capacity_base=100,
+        speed_service=Decimal("1"),
+        menu={"r": Decimal("10")},
+        active_recipes=["r"],
+    )
+    r1.staffing_level = r2.staffing_level = 2
+
+    before = market.allocate_demand([r1, r2], turn=1)
+    assert before["r1"].allocated_demand == before["r2"].allocated_demand
+
+    manager = ReviewManager()
+    manager.add_review(r1, Decimal("5"))
+
+    after = market.allocate_demand([r1, r2], turn=2)
+    assert after["r1"].allocated_demand > after["r2"].allocated_demand

--- a/tests/test_staff_planning.py
+++ b/tests/test_staff_planning.py
@@ -1,0 +1,28 @@
+from decimal import Decimal
+
+from src.foodops_pro.core.staff_planner import StaffPlanner, Shift
+from src.foodops_pro.domain.employee import Employee, EmployeePosition, EmployeeContract
+
+
+def make_employee(id_: str, salary: str) -> Employee:
+    return Employee(
+        id=id_,
+        name=id_,
+        position=EmployeePosition.SALLE,
+        contract=EmployeeContract.CDI,
+        salary_gross_monthly=Decimal(salary),
+    )
+
+
+def test_staff_planner_cost_and_satisfaction():
+    planner = StaffPlanner()
+    emp1 = make_employee("e1", "2000")
+    emp2 = make_employee("e2", "2000")
+    shifts = [Shift(emp1, Decimal("8")), Shift(emp2, Decimal("4"))]
+
+    result = planner.evaluate(Decimal("16"), shifts)
+    # 12h scheduled over 16h requirement -> 0.75 satisfaction
+    assert result.satisfaction == Decimal("0.75")
+    hourly = emp1.hourly_rate  # same for both
+    expected_cost = hourly * Decimal("12")
+    assert result.total_cost == expected_cost

--- a/tests/test_supplier_orders.py
+++ b/tests/test_supplier_orders.py
@@ -1,0 +1,34 @@
+from decimal import Decimal
+from datetime import date
+import pytest
+
+from src.foodops_pro.domain.supplier import Supplier
+
+
+def test_supplier_quantity_and_lead_time():
+    supplier = Supplier(
+        id="s1",
+        name="Fournisseur",
+        reliability=Decimal("0.9"),
+        lead_time_days=2,
+        min_order_value=Decimal("100"),
+        min_order_quantity=Decimal("5"),
+        max_order_quantity=Decimal("20"),
+        shipping_cost=Decimal("10"),
+    )
+
+    # Quantity below minimum
+    with pytest.raises(ValueError):
+        supplier.calculate_total_cost(Decimal("120"), Decimal("2"))
+
+    # Quantity above maximum
+    with pytest.raises(ValueError):
+        supplier.calculate_total_cost(Decimal("500"), Decimal("25"))
+
+    # Valid order
+    total = supplier.calculate_total_cost(Decimal("150"), Decimal("10"))
+    assert total == Decimal("160")  # 150 + shipping 10
+
+    # Lead time
+    delivery = supplier.get_expected_delivery_date(date(2024, 1, 1))
+    assert delivery == date(2024, 1, 3)


### PR DESCRIPTION
## Summary
- extend suppliers with minimum/maximum order quantities and delivery date helper
- implement simple staff scheduling planner tracking cost and satisfaction
- add online review manager that adjusts restaurant reputation and influences demand
- repair stray code in market module

## Testing
- `pytest tests/test_supplier_orders.py tests/test_staff_planning.py tests/test_reviews_market.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'Foodopsmini'; IndentationError in cli_pro.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b2225b448333a42285d3d77fa692