### PR TITLE
feat: add detailed market turn report

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,17 @@ Scénarios pédagogiques types :
 - **RH** : coût personnel, productivité
 - **Rapports** : compte de résultat, bilan, flux de trésorerie, KPIs et analyse
 
+### Rapport de tour
+Après chaque tour, un rapport récapitulatif affiche :
+
+- la demande initiale et les modificateurs appliqués (saison, événements, concurrence) ;
+- le nombre de clients servis et perdus par restaurant ;
+- le chiffre d'affaires détaillé par recette ;
+- les facteurs de satisfaction (type, prix, qualité, production) ;
+- ainsi que les indicateurs globaux du marché (CA total, satisfaction de la demande).
+
+Ce rapport permet de comprendre comment le contexte influence les ventes et d'ajuster sa stratégie pour le tour suivant.
+
 ## 🧪 Tests
 
 ```bash

--- a/src/foodops_pro/cli_pro.py
+++ b/src/foodops_pro/cli_pro.py
@@ -18,6 +18,7 @@ from .core.market import MarketEngine
 from .core.costing import RecipeCostCalculator
 from .ui.console_ui import ConsoleUI
 from .ui.decision_menu import DecisionMenu
+from .ui.financial_reports import FinancialReports
 from .admin.admin_config import AdminConfigManager, AdminSettings
 
 
@@ -62,6 +63,7 @@ class FoodOpsProGame:
         self.market_engine = MarketEngine(self.scenario, self.scenario.random_seed)
         self.cost_calculator = RecipeCostCalculator(self.ingredients)
         self.decision_menu = DecisionMenu(self.ui, self.cost_calculator)
+        self.financial_reports = FinancialReports(self.ui)
         # Injection des catalogues et paramètres admin
         self.decision_menu.set_suppliers_catalog(self.suppliers_catalog)
         self.decision_menu.set_suppliers_map(self.suppliers)
@@ -624,6 +626,9 @@ class FoodOpsProGame:
                     lines.append(f"• {r.name}: {ta:.2f} × {pf:.2f} × {qf:.2f} × {pq:.2f}")
                 self.ui.print_box(lines, style='info')
         except Exception as e:
+            if self.admin_mode:
+                print(f"[DEBUG] display factors failed: {e}")
+
         # Chiffres clés par restaurant
         try:
             key_lines = ["📌 Chiffres clés (tour):"]
@@ -668,6 +673,11 @@ class FoodOpsProGame:
 
         print()
         self.ui.print_box(analysis_lines, style="warning")
+
+        # Rapport détaillé de marché
+        self.financial_reports.show_turn_report(
+            self.market_engine, self.recipes, self.players + self.ai_competitors
+        )
 
     def _update_restaurants(self, results: Dict) -> None:
         """Met à jour l'état des restaurants après le tour."""


### PR DESCRIPTION
## Summary
- generate per-turn market report with demand modifiers, recipe revenues and satisfaction factors
- display detailed report from CLI after each round
- document how to interpret turn reports in README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'Foodopsmini')*


------
https://chatgpt.com/codex/tasks/task_e_68a7b3a9689c83338f19b332f8f1bcda