### PR TITLE
feat: scale demand with players and days

### DIFF
--- a/examples/scenarios/base.yaml
+++ b/examples/scenarios/base.yaml
@@ -3,7 +3,8 @@ description: "Scénario d'initiation avec 3 segments de marché et concurrence m
 
 # Paramètres de jeu
 turns: 12
-base_demand: 420
+base_demand: 420  # clients moyens par jour
+days_per_turn: 1
 demand_noise: 0.08
 ai_competitors: 2
 random_seed: 42

--- a/scenarios/demo.yaml
+++ b/scenarios/demo.yaml
@@ -4,7 +4,8 @@ difficulty: "facile"
 
 # Configuration du marché
 market:
-  base_demand: 300
+  base_demand: 300  # clients moyens par jour
+  days_per_turn: 1
   demand_noise: 0.10
   price_sensitivity: 1.0
   quality_importance: 0.8

--- a/scenarios/standard.yaml
+++ b/scenarios/standard.yaml
@@ -4,7 +4,8 @@ difficulty: "normal"
 
 # Configuration du marché
 market:
-  base_demand: 420
+  base_demand: 420  # clients moyens par jour
+  days_per_turn: 1
   demand_noise: 0.15
   price_sensitivity: 1.2
   quality_importance: 1.0

--- a/src/foodops_pro/core/market.py
+++ b/src/foodops_pro/core/market.py
@@ -103,7 +103,9 @@ class MarketEngine:
         market_modifiers = self.competition_manager.get_market_modifiers()
 
         # Calcul de la demande totale avec bruit et événements
-        base_demand = self.scenario.calculate_total_demand(turn, month)
+        base_demand = self.scenario.calculate_total_demand(
+            turn, month, players_count=len(restaurants)
+        )
         noise_factor = 1 + self.rng.uniform(
             -float(self.scenario.demand_noise), float(self.scenario.demand_noise)
         )
@@ -421,52 +423,6 @@ class MarketEngine:
         except Exception:
             return Decimal('1.00')
 
-            restaurant: Restaurant évalué
-            segment: Segment de marché
-
-        Returns:
-            Facteur qualité (0.5 à 2.0)
-        """
-        # NOUVEAU: Utilisation du score de qualité du restaurant
-        quality_score = restaurant.get_overall_quality_score()
-
-        # Conversion du score qualité (1-5) en facteur d'attractivité
-        if quality_score <= Decimal("1.5"):
-            base_factor = Decimal("0.70")  # -30%
-        elif quality_score <= Decimal("2.5"):
-            base_factor = Decimal("1.00")  # Neutre
-        elif quality_score <= Decimal("3.5"):
-            base_factor = Decimal("1.20")  # +20%
-        elif quality_score <= Decimal("4.5"):
-            base_factor = Decimal("1.40")  # +40%
-        else:
-            base_factor = Decimal("1.60")  # +60%
-
-        # NOUVEAU: Sensibilité à la qualité par segment
-        segment_name = segment.name.lower()
-        quality_sensitivity = Decimal("1.0")
-
-        if "student" in segment_name or "étudiant" in segment_name:
-            quality_sensitivity = Decimal("0.6")  # Moins sensibles
-        elif "foodie" in segment_name or "gourmet" in segment_name:
-            quality_sensitivity = Decimal("1.4")  # Très sensibles
-        elif "family" in segment_name or "famille" in segment_name:
-            quality_sensitivity = Decimal("1.0")  # Sensibilité normale
-
-        # Ajustement selon la sensibilité du segment
-        if base_factor > Decimal("1.0"):
-            bonus = (base_factor - Decimal("1.0")) * quality_sensitivity
-            final_factor = Decimal("1.0") + bonus
-        else:
-            malus = (Decimal("1.0") - base_factor) * quality_sensitivity
-            final_factor = Decimal("1.0") - malus
-        # NOUVEAU: Impact de la réputation
-        reputation_factor = restaurant.reputation / Decimal("10")  # 0-1
-        reputation_bonus = (reputation_factor - Decimal("0.5")) * Decimal("0.2")  # ±10%
-        final_factor += reputation_bonus
-        return max(Decimal("0.5"), min(Decimal("2.0"), final_factor))
-
-        return max(Decimal("0.5"), min(Decimal("2.0"), final_factor))
 
     def _get_season_name(self, month: int) -> str:
         """Retourne le nom de la saison selon le mois."""

--- a/src/foodops_pro/io/data_loader.py
+++ b/src/foodops_pro/io/data_loader.py
@@ -249,6 +249,7 @@ class DataLoader:
             "description": "Scénario par défaut quand PyYAML n'est pas installé",
             "turns": 12,
             "base_demand": 420,
+            "days_per_turn": 1,
             "demand_noise": 0.08,
             "ai_competitors": 2,
             "random_seed": 42,
@@ -419,6 +420,7 @@ class DataLoader:
             description=data["description"],
             turns=data["turns"],
             base_demand=data["base_demand"],
+            days_per_turn=data.get("days_per_turn", 1),
             demand_noise=Decimal(str(data["demand_noise"])),
             segments=segments,
             vat_rates=vat_rates,
@@ -438,6 +440,7 @@ class DataLoader:
             "difficulty": "normal",
             "market": {
                 "base_demand": 420,
+                "days_per_turn": 1,
                 "demand_noise": 0.15,
                 "price_sensitivity": 1.2,
                 "quality_importance": 1.0,

--- a/tests/test_demand_players.py
+++ b/tests/test_demand_players.py
@@ -1,0 +1,29 @@
+from decimal import Decimal
+
+from src.foodops_pro.domain.scenario import Scenario, MarketSegment
+from src.foodops_pro.domain.restaurant import RestaurantType
+
+
+def test_total_demand_scales_with_players():
+    segment = MarketSegment(
+        name="Unique",
+        share=Decimal("1.0"),
+        budget=Decimal("10"),
+        type_affinity={RestaurantType.FAST: Decimal("1.0")},
+    )
+    scenario = Scenario(
+        name="Test",
+        description="",
+        turns=1,
+        base_demand=100,
+        days_per_turn=2,
+        demand_noise=Decimal("0"),
+        segments=[segment],
+    )
+
+    demand_one = scenario.calculate_total_demand(turn=1, month=1, players_count=1)
+    demand_two = scenario.calculate_total_demand(turn=1, month=1, players_count=2)
+
+    assert demand_one == 200
+    assert demand_two == 400
+    assert demand_two == demand_one * 2


### PR DESCRIPTION
## Summary
- support `days_per_turn` in scenarios
- compute demand per turn as daily base demand scaled by days and number of players
- add tests for player-based demand scaling

## Testing
- `pytest tests/test_demand_players.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'Foodopsmini'; IndentationError in cli_pro.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b6f91f448333984add28e343cbe8