### PR TITLE
feat: add turn-based financial reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,18 @@ Scénarios pédagogiques types :
 - **Marché** : part de marché, satisfaction de la demande
 - **RH** : coût personnel, productivité
 - **Rapports** : compte de résultat, bilan, flux de trésorerie, KPIs et analyse
+- **Rapport de tour** : demande initiale, modificateurs (saison, événements, concurrence), clients servis/perdus, CA par segment et recette, facteurs de satisfaction
+
+### Interpréter le rapport de tour
+
+Après chaque tour, un rapport textuel récapitule :
+
+- la demande initiale et les modificateurs appliqués (saison, événements, concurrence) ;
+- le nombre de clients servis et perdus pour chaque restaurant ;
+- le chiffre d'affaires détaillé par segment de marché et par recette ;
+- les facteurs de satisfaction (affinité de type, sensibilité prix, qualité, qualité de production) et la satisfaction finale.
+
+Ce rapport permet de comprendre l'impact des décisions et du contexte de marché sur la performance du tour.
 
 ## 🧪 Tests
 


### PR DESCRIPTION
## Summary
- track per-segment demand and revenues in market engine
- generate detailed turn report with demand modifiers, revenues by segment and recipe, and satisfaction factors
- display new report every turn in pro CLI and document interpretation in README

## Testing
- `PYTHONPATH=. python -m pytest tests/test_market_allocation.py tests/test_recipe_costing.py tests/test_ledger_vat.py tests/test_payroll.py tests/test_integration.py -q` *(fails: AssertionError, AttributeError, TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b700bc9c8333836b9af5ccdbdfaa