### PR TITLE
Improve error handling during demand allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,18 @@ Scénarios pédagogiques types :
 - **RH** : coût personnel, productivité
 - **Rapports** : compte de résultat, bilan, flux de trésorerie, KPIs et analyse
 
+## ⚠️ Gestion des incohérences de demande
+
+Des écarts peuvent survenir lors de l'ajustement des clients servis en fonction des
+unités prêtes disponibles (mode *production-aware*). Lorsque cela se produit :
+
+- l'erreur est journalisée via `logging` (niveau ERROR),
+- le message est ajouté à `turn_history` dans `AllocationResult.errors` pour chaque
+  restaurant concerné.
+
+Ces informations permettent d'analyser a posteriori les incohérences entre demande
+allouée et service effectif.
+
 ## 🧪 Tests
 
 ```bash


### PR DESCRIPTION
## Summary
- log production-aware allocation errors instead of swallowing exceptions
- track allocation errors per restaurant via `AllocationResult.errors`
- document how allocation errors are logged and stored for later analysis

## Testing
- `pytest` *(fails: SyntaxError in src/foodops_pro/core/market.py: unterminated string literal)*


------
https://chatgpt.com/codex/tasks/task_e_68a7ba8b80a08333b759d85ad7609bdd