### PR TITLE
Add expense categories and balance aggregation for financial metrics

### DIFF
--- a/src/foodops_pro/core/ledger.py
+++ b/src/foodops_pro/core/ledger.py
@@ -135,6 +135,12 @@ class Ledger:
         self.accounts: Dict[str, Account] = {}
         self.entries: List[AccountingEntry] = []
         self._initialize_chart_of_accounts()
+        # Mapping des catégories de comptes de charges
+        self.account_categories: Dict[str, List[str]] = {
+            "loyer": ["613"],
+            "energie": ["6061"],
+            "marketing": ["623"],
+        }
 
     def _initialize_chart_of_accounts(self) -> None:
         """Initialise le plan comptable de base."""
@@ -165,6 +171,8 @@ class Ledger:
             "601", "Achats matières premières", AccountType.EXPENSE
         )
         self.accounts["613"] = Account("613", "Loyers", AccountType.EXPENSE)
+        self.accounts["6061"] = Account("6061", "Énergie", AccountType.EXPENSE)
+        self.accounts["623"] = Account("623", "Marketing", AccountType.EXPENSE)
         self.accounts["621"] = Account(
             "621", "Personnel extérieur", AccountType.EXPENSE
         )
@@ -359,6 +367,14 @@ class Ledger:
         return self.accounts.get(
             account_number, Account("", "", AccountType.ASSET)
         ).balance
+
+    def get_category_balance(self, category: str) -> Decimal:
+        """Retourne le solde total d'une catégorie de charges."""
+        accounts = self.account_categories.get(category, [])
+        total = Decimal("0")
+        for acc in accounts:
+            total += self.get_balance(acc)
+        return total
 
     def get_trial_balance(self) -> Dict[str, Dict[str, Decimal]]:
         """

--- a/src/foodops_pro/core/market.py
+++ b/src/foodops_pro/core/market.py
@@ -421,6 +421,10 @@ class MarketEngine:
         except Exception:
             return Decimal('1.00')
 
+    def _get_quality_factor(self, restaurant: Restaurant, segment: MarketSegment) -> Decimal:
+        """Calcule un facteur de qualité global pour un segment donné.
+
+        Args:
             restaurant: Restaurant évalué
             segment: Segment de marché
 
@@ -460,11 +464,11 @@ class MarketEngine:
         else:
             malus = (Decimal("1.0") - base_factor) * quality_sensitivity
             final_factor = Decimal("1.0") - malus
+
         # NOUVEAU: Impact de la réputation
         reputation_factor = restaurant.reputation / Decimal("10")  # 0-1
         reputation_bonus = (reputation_factor - Decimal("0.5")) * Decimal("0.2")  # ±10%
         final_factor += reputation_bonus
-        return max(Decimal("0.5"), min(Decimal("2.0"), final_factor))
 
         return max(Decimal("0.5"), min(Decimal("2.0"), final_factor))
 
@@ -485,7 +489,7 @@ class MarketEngine:
 
         Args:
             segment_name: Nom du segment
-            month: Mois de l'année (1-12)
+            month: Mois de l\'annee (1-12)
 
         Returns:
             Multiplicateur saisonnier (0.8 à 1.3)


### PR DESCRIPTION
## Summary
- classify expenses by adding energy and marketing accounts with category support in the ledger
- compute detailed financial metrics from actual account balances
- extend tests to cover new expense accounts and category aggregation

## Testing
- `pytest tests/test_ledger_vat.py::TestLedger::test_record_cash_payment -q`
- `pytest tests/test_ledger_vat.py::TestLedger::test_category_balances -q`
- `pytest tests/test_integration.py::TestGameIntegration::test_payroll_and_ledger_integration -q` *(fails: 'NoneType' object is not subscriptable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ba8e0924833384a1c7706487ba8a