### PR TITLE
feat: add save manager restore

### DIFF
--- a/src/foodops_pro/__init__.py
+++ b/src/foodops_pro/__init__.py
@@ -11,5 +11,4 @@ __author__ = "FoodOps Team"
 __email__ = "contact@foodops.pro"
 
 from .domain import *
-from .core import *
 from .io import *


### PR DESCRIPTION
## Summary
- reconstruct dataclasses using a safe import mapping in SaveManager
- handle enums, decimals and dataclasses when restoring saved games
- add end-to-end test for saving and loading a game

## Testing
- `pytest tests/test_integration.py::TestSaveManager::test_save_and_load_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_68a7beb0a9c08333a634aa70b17a1de3