### PR TITLE
feat: log production errors and record in turn history

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,13 @@ Modifiez les fichiers CSV dans `src/foodops_pro/data/` :
 - Analyse concurrentielle
 - Gestion de la capacité
 
+## 🛠️ Gestion des erreurs d'allocation
+
+En cas de données incohérentes (ex. attribut `production_units_ready` invalide),
+le moteur de marché consigne l'erreur avec `logging` et l'ajoute à
+`turn_history` dans le champ `errors` du tour correspondant. Ces informations
+permettent d'analyser a posteriori les incohérences éventuelles.
+
 ## 📝 TODO et améliorations
 
 - [ ] Achats & Stocks complets (FEFO visible dans le CLI Pro)

--- a/tests/test_market_allocation.py
+++ b/tests/test_market_allocation.py
@@ -208,7 +208,9 @@ class TestMarketEngine:
         assert len(engine.turn_history) == 3
 
         for i, turn_data in enumerate(engine.turn_history):
-            assert len(turn_data) == len(sample_restaurants)
+            assert turn_data["turn"] == i + 1
+            assert len(turn_data["results"]) == len(sample_restaurants)
+            assert "errors" in turn_data
 
     def test_market_analysis(self, sample_scenario, sample_restaurants):
         """Test de l'analyse de marché."""


### PR DESCRIPTION
## Summary
- log and store production-unit allocation errors during demand allocation
- track turn metadata and errors in MarketEngine history
- document allocation error handling in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'Foodopsmini'; IndentationError in cli_pro.py)*
- `pytest tests/test_market_allocation.py::TestMarketEngine::test_turn_history -q`

------
https://chatgpt.com/codex/tasks/task_e_68a7beba93808333aa20460a9a13b4b9