### PR TITLE
feat: add month turn scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Former des futurs entrepreneurs/restaurateurs aux aspects clés de la gestion :
 
 ## ✨ Fonctionnalités
 
-- **Jeu tour par tour** multi-joueurs (1-4 joueurs sur la même machine)
+- **Jeu tour par tour** multi-joueurs (1-4 joueurs sur la même machine, 1 tour = 1 mois standard de 4 semaines de 7 jours, d'autres échelles à venir)
 - **Modèles réalistes** : 35+ ingrédients, 20+ recettes, fournisseurs, employés
 - **Marché dynamique** avec 3 segments de clientèle et concurrence IA
 - **Comptabilité française** avec TVA (10%, 5.5%, 20%), charges sociales, amortissements

--- a/src/foodops_pro/core/payroll_fr.py
+++ b/src/foodops_pro/core/payroll_fr.py
@@ -76,7 +76,7 @@ class PayrollCalculator:
     def calculate_payroll(
         self,
         employee: Employee,
-        hours_worked: Decimal = Decimal("151.67"),
+        hours_worked: Decimal = Decimal("140"),
         sunday_hours: Decimal = Decimal("0"),
         period: str = "",
     ) -> PayrollResult:
@@ -93,7 +93,7 @@ class PayrollCalculator:
             Résultat du calcul de paie
         """
         # Heures normales et supplémentaires
-        monthly_normal_hours = Decimal("151.67")  # 35h * 52 semaines / 12 mois
+        monthly_normal_hours = Decimal("140")  # 35h * 4 semaines / mois standard
         normal_hours = min(hours_worked, monthly_normal_hours)
         overtime_hours = max(Decimal("0"), hours_worked - monthly_normal_hours)
 
@@ -266,9 +266,9 @@ class PayrollCalculator:
 
         for employee in employees:
             hours = (
-                hours_per_employee.get(employee.id, Decimal("151.67"))
+                hours_per_employee.get(employee.id, Decimal("140"))
                 if hours_per_employee
-                else Decimal("151.67")
+                else Decimal("140")
             )
             sunday_hours = (
                 sunday_hours_per_employee.get(employee.id, Decimal("0"))

--- a/src/foodops_pro/domain/employee.py
+++ b/src/foodops_pro/domain/employee.py
@@ -97,7 +97,7 @@ class Employee:
     @property
     def hourly_rate(self) -> Decimal:
         """Taux horaire brut (base 35h/semaine)."""
-        monthly_hours = Decimal("151.67")  # 35h * 52 semaines / 12 mois
+        monthly_hours = Decimal("140")  # 35h * 4 semaines / mois standard
         return self.effective_salary_monthly / monthly_hours
 
     @property

--- a/src/foodops_pro/domain/scenario.py
+++ b/src/foodops_pro/domain/scenario.py
@@ -93,6 +93,7 @@ class Scenario:
         name: Nom du scénario
         description: Description du scénario
         turns: Nombre de tours
+        turn_scale: Unité de temps des tours ("month" = mois de 4 semaines)
         base_demand: Demande de base par tour
         demand_noise: Variabilité de la demande (0.0-1.0)
         segments: Segments de marché
@@ -109,6 +110,7 @@ class Scenario:
     base_demand: int
     demand_noise: Decimal
     segments: List[MarketSegment]
+    turn_scale: str = "month"
     vat_rates: Dict[str, Decimal] = field(default_factory=dict)
     social_charges: Dict[str, Decimal] = field(default_factory=dict)
     interest_rate: Decimal = Decimal("0.05")
@@ -197,7 +199,7 @@ class Scenario:
         Calcule la demande totale pour un tour donné.
 
         Args:
-            turn: Numéro du tour
+            turn: Numéro du tour (1 tour = 1 mois standard de 4 semaines)
             month: Mois de l'année (pour saisonnalité)
 
         Returns:

--- a/tests/test_payroll.py
+++ b/tests/test_payroll.py
@@ -168,13 +168,13 @@ class TestPayrollCalculator:
         calculator = PayrollCalculator(sample_social_charges_config)
         employee = sample_employees[0]  # CDI, éligible aux heures sup
 
-        # 160 heures (151.67 normales + 8.33 heures sup)
+        # 160 heures (140 normales + 20 heures sup)
         hours_worked = Decimal("160.0")
 
         result = calculator.calculate_payroll(employee, hours_worked=hours_worked)
 
         # Vérification des heures supplémentaires
-        normal_hours = Decimal("151.67")
+        normal_hours = Decimal("140")
         overtime_hours = hours_worked - normal_hours
 
         assert result.overtime_hours == overtime_hours
@@ -290,7 +290,7 @@ class TestPayrollCalculator:
         # Heures spécifiques par employé
         hours_per_employee = {
             "emp1": Decimal("155.0"),
-            "emp2": Decimal("151.67"),
+            "emp2": Decimal("140.0"),
             "emp3": Decimal("140.0"),
             "emp4": Decimal("75.0"),  # Mi-temps
         }
@@ -345,7 +345,7 @@ class TestPayrollCalculator:
         employee = sample_employees[0]
 
         # Calcul manuel
-        monthly_hours = Decimal("151.67")  # 35h * 52 semaines / 12 mois
+        monthly_hours = Decimal("140")  # 35h * 4 semaines / mois standard
         expected_hourly_rate = employee.salary_gross_monthly / monthly_hours
 
         assert abs(employee.hourly_rate - expected_hourly_rate) < Decimal("0.01")
@@ -355,7 +355,7 @@ class TestPayrollCalculator:
         employee = sample_employees[3]  # Mi-temps
 
         # Le taux horaire devrait être basé sur le salaire effectif
-        monthly_hours = Decimal("151.67")
+        monthly_hours = Decimal("140")
         effective_salary = employee.salary_gross_monthly * employee.part_time_ratio
         expected_hourly_rate = effective_salary / monthly_hours
 
@@ -369,7 +369,7 @@ class TestPayrollCalculator:
         employee = sample_employees[0]
 
         # 12 heures supplémentaires (8 à 25%, 4 à 50%)
-        hours_worked = Decimal("163.67")  # 151.67 + 12
+        hours_worked = Decimal("152.0")  # 140 + 12 heures sup
 
         result = calculator.calculate_payroll(employee, hours_worked=hours_worked)
 


### PR DESCRIPTION
## Summary
- define turn_scale in scenarios to track time unit
- base payroll calculations on a standard 4-week month
- document the monthly time scale and update payroll tests

## Testing
- `pytest tests/test_payroll.py` *(fails: ImportError: SyntaxError in core/market.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c2c579848333a75ab366fba9af1e