### PR TITLE
Add lightweight game server with ranking and message board

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Former des futurs entrepreneurs/restaurateurs aux aspects clés de la gestion :
 ## ✨ Fonctionnalités
 
 - **Jeu tour par tour** multi-joueurs (1-4 joueurs sur la même machine)
+- **Serveur léger** pour parties réseau avec synchronisation des tours,
+  classement et mur d'actualité
 - **Modèles réalistes** : 35+ ingrédients, 20+ recettes, fournisseurs, employés
 - **Marché dynamique** avec 3 segments de clientèle et concurrence IA
 - **Comptabilité française** avec TVA (10%, 5.5%, 20%), charges sociales, amortissements
@@ -89,6 +91,25 @@ python start_pro.py        # Version Pro
 python start_admin.py      # Mode Admin
 python start_demo.py       # Démo 3 tours
 ```
+
+## 🌐 Serveur léger
+
+Un petit serveur FastAPI est disponible pour organiser des parties
+réseau. Il synchronise les tours, affiche un classement et propose un
+mur d'actualité pour que les équipes commentent leurs stratégies.
+
+Lancer le serveur :
+
+```bash
+uvicorn foodops_pro.server:app --reload
+```
+
+Les endpoints principaux :
+
+- `POST /join` – rejoindre une session
+- `POST /submit` – envoyer son score de tour
+- `GET /ranking` – consulter le classement actuel
+- `GET/POST /messages` – mur d'actualité
 
 ### Presets de configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ classifiers = [
 dependencies = [
     "pyyaml>=6.0",
     "pandas>=2.0.0",
+    "fastapi>=0.104.1",
+    "uvicorn>=0.23.2",
 ]
 
 [project.optional-dependencies]

--- a/src/foodops_pro/server.py
+++ b/src/foodops_pro/server.py
@@ -1,0 +1,115 @@
+"""Simple FastAPI server for hosting a FoodOps game.
+
+This lightweight server allows teams to join a session, submit their
+turn scores, display a ranking after each round and exchange messages
+via a small discussion board.
+
+It is intentionally minimalistic: the state is kept in memory and will be
+reset every time the process restarts. The server is meant for small
+workshop or classroom games where a quick way to synchronise players is
+necessary without deploying heavy infrastructure.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI(title="FoodOps Light Server")
+
+
+class JoinRequest(BaseModel):
+    """Payload used when a team joins the game."""
+
+    player_name: str
+
+
+class SubmitRequest(BaseModel):
+    """Payload sent at the end of a turn with the score of a player."""
+
+    player_name: str
+    score: int
+
+
+class MessageRequest(BaseModel):
+    """Payload for posting a message on the discussion wall."""
+
+    player_name: str
+    message: str
+
+
+# --- In-memory state -----------------------------------------------------
+players: dict[str, int] = {}
+# Tracks whether a player has submitted its score for the current turn
+turn_submissions: dict[str, bool] = {}
+current_turn: int = 1
+# List of dicts with keys: player, message, timestamp
+messages: list[dict[str, str]] = []
+
+
+@app.post("/join")
+def join(req: JoinRequest) -> dict[str, object]:
+    """Register a new player on the server.
+
+    If the player already exists nothing happens and the current state is
+    returned. The endpoint answers with the current turn number so the
+    client can synchronise.
+    """
+
+    if req.player_name not in players:
+        players[req.player_name] = 0
+    return {"status": "ok", "current_turn": current_turn}
+
+
+@app.post("/submit")
+def submit(req: SubmitRequest) -> dict[str, object]:
+    """Submit the result of a player for the current turn.
+
+    The total score of the player is updated. When all registered players
+    have submitted their score the server automatically advances to the
+    next turn and clears the submission tracker.
+    """
+
+    global current_turn
+    players.setdefault(req.player_name, 0)
+    players[req.player_name] += req.score
+    turn_submissions[req.player_name] = True
+
+    if len(turn_submissions) == len(players):
+        turn_submissions.clear()
+        current_turn += 1
+
+    return {"status": "ok", "current_turn": current_turn}
+
+
+@app.get("/ranking")
+def ranking() -> dict[str, object]:
+    """Return the ranking ordered by total score."""
+
+    ordered: list[tuple[str, int]] = sorted(
+        players.items(), key=lambda item: item[1], reverse=True
+    )
+    return {"current_turn": current_turn, "ranking": ordered}
+
+
+@app.post("/messages")
+def post_message(req: MessageRequest) -> dict[str, str]:
+    """Store a message on the discussion wall."""
+
+    messages.append(
+        {
+            "player": req.player_name,
+            "message": req.message,
+            "timestamp": datetime.utcnow().isoformat(timespec="seconds"),
+        }
+    )
+    return {"status": "ok"}
+
+
+@app.get("/messages")
+def get_messages() -> dict[str, list[dict[str, str]]]:
+    """Retrieve all messages posted so far."""
+
+    return {"messages": messages}


### PR DESCRIPTION
## Summary
- add FastAPI server to host games, sync turns, and manage rankings
- document new lightweight server endpoints and usage
- include FastAPI and Uvicorn dependencies

## Testing
- `ruff check src/foodops_pro/server.py`
- `python -m py_compile src/foodops_pro/server.py`
- `pytest -q` *(fails: SyntaxError in src/foodops_pro/core/market.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a83c6614808333b61ef3649ae5b3eb