### PR TITLE
Add training modules with quizzes and certificate generation

### DIFF
--- a/src/foodops_pro/cli_pro.py
+++ b/src/foodops_pro/cli_pro.py
@@ -624,6 +624,8 @@ class FoodOpsProGame:
                     lines.append(f"• {r.name}: {ta:.2f} × {pf:.2f} × {qf:.2f} × {pq:.2f}")
                 self.ui.print_box(lines, style='info')
         except Exception as e:
+            # Ignore les erreurs d'affichage des facteurs pour ne pas interrompre le flux de jeu
+            self.ui.print(f"Erreur analyse attractivité: {e}", style='error')
         # Chiffres clés par restaurant
         try:
             key_lines = ["📌 Chiffres clés (tour):"]

--- a/src/foodops_pro/core/market.py
+++ b/src/foodops_pro/core/market.py
@@ -421,53 +421,6 @@ class MarketEngine:
         except Exception:
             return Decimal('1.00')
 
-            restaurant: Restaurant évalué
-            segment: Segment de marché
-
-        Returns:
-            Facteur qualité (0.5 à 2.0)
-        """
-        # NOUVEAU: Utilisation du score de qualité du restaurant
-        quality_score = restaurant.get_overall_quality_score()
-
-        # Conversion du score qualité (1-5) en facteur d'attractivité
-        if quality_score <= Decimal("1.5"):
-            base_factor = Decimal("0.70")  # -30%
-        elif quality_score <= Decimal("2.5"):
-            base_factor = Decimal("1.00")  # Neutre
-        elif quality_score <= Decimal("3.5"):
-            base_factor = Decimal("1.20")  # +20%
-        elif quality_score <= Decimal("4.5"):
-            base_factor = Decimal("1.40")  # +40%
-        else:
-            base_factor = Decimal("1.60")  # +60%
-
-        # NOUVEAU: Sensibilité à la qualité par segment
-        segment_name = segment.name.lower()
-        quality_sensitivity = Decimal("1.0")
-
-        if "student" in segment_name or "étudiant" in segment_name:
-            quality_sensitivity = Decimal("0.6")  # Moins sensibles
-        elif "foodie" in segment_name or "gourmet" in segment_name:
-            quality_sensitivity = Decimal("1.4")  # Très sensibles
-        elif "family" in segment_name or "famille" in segment_name:
-            quality_sensitivity = Decimal("1.0")  # Sensibilité normale
-
-        # Ajustement selon la sensibilité du segment
-        if base_factor > Decimal("1.0"):
-            bonus = (base_factor - Decimal("1.0")) * quality_sensitivity
-            final_factor = Decimal("1.0") + bonus
-        else:
-            malus = (Decimal("1.0") - base_factor) * quality_sensitivity
-            final_factor = Decimal("1.0") - malus
-        # NOUVEAU: Impact de la réputation
-        reputation_factor = restaurant.reputation / Decimal("10")  # 0-1
-        reputation_bonus = (reputation_factor - Decimal("0.5")) * Decimal("0.2")  # ±10%
-        final_factor += reputation_bonus
-        return max(Decimal("0.5"), min(Decimal("2.0"), final_factor))
-
-        return max(Decimal("0.5"), min(Decimal("2.0"), final_factor))
-
     def _get_season_name(self, month: int) -> str:
         """Retourne le nom de la saison selon le mois."""
         if month in [12, 1, 2]:

--- a/src/foodops_pro/training.py
+++ b/src/foodops_pro/training.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+"""Module de parcours pédagogique pour FoodOps.
+
+Ce module propose une structure simple pour définir des modules
+pédagogiques avec objectif, quiz de validation et génération
+de certificat lorsque tout le parcours est complété.
+"""
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class QuizQuestion:
+    """Représente une question de quiz."""
+
+    question: str
+    options: List[str]
+    answer_index: int  # index de la bonne réponse dans ``options``
+
+    def is_correct(self, choice: int) -> bool:
+        """Vérifie si la réponse choisie est correcte."""
+        return choice == self.answer_index
+
+
+@dataclass
+class TrainingModule:
+    """Module d'apprentissage avec objectif et quiz."""
+
+    name: str
+    objective: str
+    quiz: List[QuizQuestion] = field(default_factory=list)
+
+
+@dataclass
+class TrainingPath:
+    """Parcours de formation composé de plusieurs modules."""
+
+    modules: List[TrainingModule]
+    current_index: int = 0
+
+    def current_module(self) -> TrainingModule | None:
+        """Retourne le module en cours ou ``None`` si terminé."""
+        if self.current_index < len(self.modules):
+            return self.modules[self.current_index]
+        return None
+
+    def answer_current_quiz(self, choice: int) -> bool:
+        """Valide la réponse du quiz du module courant.
+
+        Si la réponse est correcte, passe au module suivant.
+        """
+        module = self.current_module()
+        if not module or not module.quiz:
+            return False
+        question = module.quiz[0]
+        ok = question.is_correct(choice)
+        if ok:
+            self.current_index += 1
+        return ok
+
+    def is_completed(self) -> bool:
+        """Indique si tous les modules ont été validés."""
+        return self.current_index >= len(self.modules)
+
+    def generate_certificate(self, learner: str, filename: str | None = None) -> str:
+        """Génère un certificat simple pour l'apprenant.
+
+        Parameters
+        ----------
+        learner: str
+            Nom de l'apprenant.
+        filename: str | None
+            Chemin du fichier où sauvegarder le certificat. Si ``None``,
+            le certificat est seulement renvoyé.
+
+        Returns
+        -------
+        str
+            Le texte du certificat généré.
+
+        Raises
+        ------
+        ValueError
+            Si le parcours n'est pas terminé.
+        """
+        if not self.is_completed():
+            raise ValueError("Parcours non terminé")
+        certificate = (
+            f"Certificat de réussite - {learner}\n" f"Modules complétés: {len(self.modules)}"
+        )
+        if filename:
+            with open(filename, "w", encoding="utf-8") as f:
+                f.write(certificate)
+        return certificate
+
+
+# Parcours par défaut utilisé par l'application ou les tests
+DEFAULT_PATH = TrainingPath(
+    modules=[
+        TrainingModule(
+            name="Gestion des stocks FEFO",
+            objective="Gérer son stock avec la méthode First Expired, First Out.",
+            quiz=[
+                QuizQuestion(
+                    question="Quel est l'objectif principal de la méthode FEFO ?",
+                    options=[
+                        "Vendre en premier les produits les plus chers",
+                        "Utiliser d'abord les produits qui expirent le plus tôt",
+                        "Réduire les coûts de main d'œuvre",
+                    ],
+                    answer_index=1,
+                )
+            ],
+        ),
+        TrainingModule(
+            name="Menu engineering",
+            objective="Optimiser son menu pour améliorer la marge.",
+            quiz=[
+                QuizQuestion(
+                    question="Quelle action améliore la marge d'une recette ?",
+                    options=[
+                        "Augmenter le prix sans toucher aux ingrédients",
+                        "Diminuer la taille de la portion ou le coût des ingrédients",
+                        "Augmenter le nombre de serveurs",
+                    ],
+                    answer_index=1,
+                )
+            ],
+        ),
+        TrainingModule(
+            name="Comptabilité de base",
+            objective="Calculer un compte de résultat simplifié.",
+            quiz=[
+                QuizQuestion(
+                    question="Quel élément n'entre pas dans le compte de résultat ?",
+                    options=[
+                        "Chiffre d'affaires",
+                        "Stock de marchandises",
+                        "Charges d'exploitation",
+                    ],
+                    answer_index=1,
+                )
+            ],
+        ),
+    ]
+)
+

--- a/tests/test_training_module.py
+++ b/tests/test_training_module.py
@@ -1,0 +1,33 @@
+from src.foodops_pro.training import TrainingPath, TrainingModule, QuizQuestion
+
+
+def test_training_path_progress_and_certificate(tmp_path):
+    modules = [
+        TrainingModule(
+            name="Module 1",
+            objective="Objectif 1",
+            quiz=[QuizQuestion("Q1", ["A", "B"], 0)],
+        ),
+        TrainingModule(
+            name="Module 2",
+            objective="Objectif 2",
+            quiz=[QuizQuestion("Q2", ["A", "B"], 1)],
+        ),
+    ]
+    path = TrainingPath(modules)
+
+    # Répondre correctement au premier quiz
+    assert path.answer_current_quiz(0)
+    assert path.current_index == 1
+
+    # Mauvaise réponse au second quiz
+    assert not path.answer_current_quiz(0)
+    assert path.current_index == 1
+
+    # Bonne réponse et génération de certificat
+    assert path.answer_current_quiz(1)
+    assert path.is_completed()
+    cert_file = tmp_path / "cert.txt"
+    cert_text = path.generate_certificate("Alice", filename=cert_file)
+    assert "Alice" in cert_text
+    assert cert_file.read_text(encoding="utf-8") == cert_text


### PR DESCRIPTION
## Summary
- fix syntax errors in market engine and handle attractivity analysis exceptions
- add modular training path with objectives, quizzes, and certificate generation
- include unit test for training path progression

## Testing
- `pytest tests/test_training_module.py -q`
- `pytest tests -q` *(fails: ModuleNotFoundError: No module named 'Foodopsmini')*

------
https://chatgpt.com/codex/tasks/task_e_68a83c65a94c833399c2a7e6a1bb3c46