### PR TITLE
Handle special day events in weekly schedule and reports

### DIFF
--- a/src/foodops_pro/core/production.py
+++ b/src/foodops_pro/core/production.py
@@ -1,36 +1,43 @@
-"""
-Module de production (MVP): planifie des unités prêtes à servir par recette
-à partir des stocks disponibles et de la capacité, puis consomme les ingrédients.
-"""
+"""Module de production (MVP): planifie les unités prêtes à servir."""
+
 from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Dict, List
+from datetime import date
 from decimal import Decimal
+from typing import Any
 
 from ..domain.recipe import Recipe
+from ..domain.schedule import SpecialDay, WeeklySchedule
 
 
 @dataclass
 class ProductionPlan:
-    servings_by_recipe: Dict[str, int]
-    cost_by_recipe_ht: Dict[str, Decimal] | None = None
-    consumed_by_recipe: Dict[str, Dict[str, Decimal]] | None = None
+    servings_by_recipe: dict[str, int]
+    cost_by_recipe_ht: dict[str, Decimal] | None = None
+    consumed_by_recipe: dict[str, dict[str, Decimal]] | None = None
+    special_day: SpecialDay | None = None
 
 
 class ProductionPlanner:
     """Planificateur de production très simple (phase 1)."""
 
-    def compute_ingredient_need_for_servings(self, recipe: Recipe, servings: int, size: str = "S") -> Dict[str, Decimal]:
+    def compute_ingredient_need_for_servings(
+        self, recipe: Recipe, servings: int, size: str = "S"
+    ) -> dict[str, Decimal]:
         """Calcule les besoins ingrédients pour un nombre de portions (taille S/L).
+
         Convention: S = 0.5x ingrédients, L = 1.0x (portion standard).
         """
         factor = Decimal("0.5") if size == "S" else Decimal("1.0")
-        needs: Dict[str, Decimal] = {}
+        needs: dict[str, Decimal] = {}
         for item in recipe.items:
             needs[item.ingredient_id] = item.qty_brute * Decimal(servings) * factor
         return needs
 
-    def compute_max_servings_from_stock(self, recipe: Recipe, stock_manager) -> int:
+    def compute_max_servings_from_stock(
+        self, recipe: Recipe, stock_manager: Any
+    ) -> int:
         """Calcule le nombre maximum de portions réalisables selon le stock disponible."""
         # Si pas de stock manager, pas de contrainte
         if stock_manager is None:
@@ -44,32 +51,64 @@ class ProductionPlanner:
             available = stock_manager.get_available_quantity(item.ingredient_id)
             if available <= 0:
                 return 0
-            possible = int((available / needed_per_serving).to_integral_value(rounding="ROUND_FLOOR"))
-            max_servings = possible if max_servings is None else min(max_servings, possible)
+            possible = int(
+                (available / needed_per_serving).to_integral_value(
+                    rounding="ROUND_FLOOR"
+                )
+            )
+            max_servings = (
+                possible if max_servings is None else min(max_servings, possible)
+            )
         return max_servings or 0
 
-    def plan(self, restaurant, recipes_by_id: Dict[str, Recipe]) -> ProductionPlan:
-        """Crée un plan par recette active, borné par stock et capacité."""
-        active = [rid for rid in getattr(restaurant, "active_recipes", []) if rid in recipes_by_id]
+    def plan(
+        self,
+        restaurant: Any,
+        recipes_by_id: dict[str, Recipe],
+        schedule: WeeklySchedule | None = None,
+        current_day: date | None = None,
+    ) -> ProductionPlan:
+        """Crée un plan par recette active, borné par stock et capacité.
+
+        Si une ``WeeklySchedule`` est fournie avec ``current_day``, la capacité
+        et les besoins sont ajustés selon l'impact attendu de cette journée.
+        """
+        active = [
+            rid
+            for rid in getattr(restaurant, "active_recipes", [])
+            if rid in recipes_by_id
+        ]
         if not active:
             return ProductionPlan(servings_by_recipe={})
 
         capacity = max(0, int(getattr(restaurant, "capacity_current", 0)))
         stock_manager = getattr(restaurant, "stock_manager", None)
 
+        special_day = None
+        if schedule is not None and current_day is not None:
+            special_day = schedule.get_special_day(current_day)
+            if special_day is not None:
+                impact = special_day.expected_impact
+                capacity = int(Decimal(capacity) * impact)
+
         # Cap max réalisable par stock pour chaque recette
-        max_by_recipe: Dict[str, int] = {}
+        max_by_recipe: dict[str, int] = {}
         total_max = 0
         for rid in active:
-            smax = self.compute_max_servings_from_stock(recipes_by_id[rid], stock_manager)
+            smax = self.compute_max_servings_from_stock(
+                recipes_by_id[rid], stock_manager
+            )
             max_by_recipe[rid] = smax
             total_max += smax
 
         if total_max == 0 or capacity == 0:
-            return ProductionPlan(servings_by_recipe={rid: 0 for rid in active})
+            return ProductionPlan(
+                servings_by_recipe=dict.fromkeys(active, 0),
+                special_day=special_day,
+            )
 
         # Répartition simple de la capacité proportionnellement au max réalisable
-        plan: Dict[str, int] = {}
+        plan: dict[str, int] = {}
         remaining_capacity = capacity
         for rid in sorted(active):
             share = (max_by_recipe[rid] / total_max) if total_max > 0 else 0
@@ -86,41 +125,49 @@ class ProductionPlanner:
                     remaining_capacity -= 1
 
         # Consommer les ingrédients selon le plan (FEFO géré côté StockManager)
-        consumed_by_recipe: Dict[str, Dict[str, Decimal]] = {}
-        cost_by_recipe: Dict[str, Decimal] = {}
+        consumed_by_recipe: dict[str, dict[str, Decimal]] = {}
+        cost_by_recipe: dict[str, Decimal] = {}
 
         if stock_manager is not None:
             for rid, servings in plan.items():
                 if servings <= 0:
                     continue
                 recipe = recipes_by_id[rid]
-                consumed: Dict[str, Decimal] = {}
-                total_cost_ht = Decimal("0")
+                consumed: dict[str, Decimal] = {}
                 for item in recipe.items:
                     total_qty = item.qty_brute * Decimal(servings)
                     stock_manager.consume_ingredient(item.ingredient_id, total_qty)
                     consumed[item.ingredient_id] = total_qty
-                    # estimation coût de revient HT: moyenne pondérée des lots n'est pas dispo ici, on approxime par coût unitaire moyen du dernier lot
-                    # Pour MVP, on ne remonte pas le coût exact; on laissera l'exécution manuelle calculer plus tard.
+                    # estimation coût de revient HT: moyenne pondérée des lots n'est pas
+                    # dispo ici, on approxime par coût unitaire moyen du dernier lot
+                    # Pour MVP, on ne remonte pas le coût exact; on laissera l'exécution
+                    # manuelle calculer plus tard.
                 consumed_by_recipe[rid] = consumed
                 # coût par portion: calculé plus tard si besoin
                 cost_by_recipe[rid] = Decimal("0")
 
-        return ProductionPlan(servings_by_recipe=plan, cost_by_recipe_ht=cost_by_recipe, consumed_by_recipe=consumed_by_recipe)
+        return ProductionPlan(
+            servings_by_recipe=plan,
+            cost_by_recipe_ht=cost_by_recipe,
+            consumed_by_recipe=consumed_by_recipe,
+            special_day=special_day,
+        )
 
 
-def apply_production_plan(restaurant, plan: ProductionPlan) -> None:
+def apply_production_plan(restaurant: Any, plan: ProductionPlan) -> None:
     """Stocke les unités prêtes à servir dans le restaurant pour le tour."""
     restaurant.production_units_ready = dict(plan.servings_by_recipe)
 
 
-def clear_previous_production(restaurant) -> None:
+def clear_previous_production(restaurant: Any) -> None:
     """Purge les unités prêtes du tour précédent (DLC=1 tour)."""
     restaurant.production_units_ready = {}
     restaurant.production_quality_score = {}
 
 
-def execute_manual_production_plan(restaurant, recipes_by_id: Dict[str, Recipe]) -> None:
+def execute_manual_production_plan(
+    restaurant: Any, recipes_by_id: dict[str, Recipe]
+) -> None:
     """Exécute le brouillon de production saisi par le joueur: consomme ingrédients et crée des unités prêtes.
 
     draft entry format: {recipe_id: {"qty": int, "size": "S"|"L", "quality": Decimal}}
@@ -135,9 +182,9 @@ def execute_manual_production_plan(restaurant, recipes_by_id: Dict[str, Recipe])
     # Préparer une carte unités prêtes
     units_ready = dict(getattr(restaurant, "production_units_ready", {}) or {})
     quality_scores = dict(getattr(restaurant, "production_quality_score", {}) or {})
-    consumed_ings: Dict[str, Dict[str, Decimal]] = {}
-    cost_per_portion: Dict[str, Decimal] = {}
-    produced_units: Dict[str, int] = {}
+    consumed_ings: dict[str, dict[str, Decimal]] = {}
+    cost_per_portion: dict[str, Decimal] = {}
+    produced_units: dict[str, int] = {}
 
     for recipe_id, params in draft.items():
         if recipe_id not in recipes_by_id:
@@ -149,7 +196,9 @@ def execute_manual_production_plan(restaurant, recipes_by_id: Dict[str, Recipe])
         if qty <= 0:
             continue
         # Calculer besoins
-        needs = ProductionPlanner().compute_ingredient_need_for_servings(recipe, qty, size)
+        needs = ProductionPlanner().compute_ingredient_need_for_servings(
+            recipe, qty, size
+        )
         # Vérifier disponibilité et consommer
         # Si pas assez d'un ingrédient: on réduit la quantité à ce qui est faisable
         max_servings = None
@@ -157,15 +206,25 @@ def execute_manual_production_plan(restaurant, recipes_by_id: Dict[str, Recipe])
             if need <= 0:
                 continue
             per_serving = need / Decimal(qty)
-            available = stock_manager.get_available_quantity(ing_id, exclude_expired=True)
-            possible = int((available / per_serving).to_integral_value(rounding="ROUND_FLOOR")) if per_serving > 0 else qty
-            max_servings = possible if max_servings is None else min(max_servings, possible)
+            available = stock_manager.get_available_quantity(
+                ing_id, exclude_expired=True
+            )
+            possible = (
+                int((available / per_serving).to_integral_value(rounding="ROUND_FLOOR"))
+                if per_serving > 0
+                else qty
+            )
+            max_servings = (
+                possible if max_servings is None else min(max_servings, possible)
+            )
         if not max_servings or max_servings <= 0:
             continue
         # Consommer ingrédients pour max_servings
-        final_needs = ProductionPlanner().compute_ingredient_need_for_servings(recipe, max_servings, size)
+        final_needs = ProductionPlanner().compute_ingredient_need_for_servings(
+            recipe, max_servings, size
+        )
         total_cost_ht = Decimal("0")
-        consumed_map: Dict[str, Decimal] = {}
+        consumed_map: dict[str, Decimal] = {}
         for ing_id, qty_need in final_needs.items():
             if qty_need > 0:
                 lots_used = stock_manager.consume_ingredient(ing_id, qty_need)
@@ -179,7 +238,9 @@ def execute_manual_production_plan(restaurant, recipes_by_id: Dict[str, Recipe])
         consumed_ings[recipe_id] = consumed_map
         produced_units[recipe_id] = produced_units.get(recipe_id, 0) + max_servings
         if max_servings > 0:
-            cost_per_portion[recipe_id] = (total_cost_ht / Decimal(max_servings)).quantize(Decimal("0.01"))
+            cost_per_portion[recipe_id] = (
+                total_cost_ht / Decimal(max_servings)
+            ).quantize(Decimal("0.01"))
 
     restaurant.production_units_ready = units_ready
     restaurant.production_quality_score = quality_scores
@@ -187,4 +248,3 @@ def execute_manual_production_plan(restaurant, recipes_by_id: Dict[str, Recipe])
     restaurant.production_produced_units = produced_units
     restaurant.production_cost_per_portion = cost_per_portion
     # On laisse le draft en place pour édition tour suivant; on pourrait aussi le vider.
-

--- a/src/foodops_pro/domain/schedule.py
+++ b/src/foodops_pro/domain/schedule.py
@@ -1,0 +1,35 @@
+"""Structures de planification hebdomadaire et jours spéciaux."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from decimal import Decimal
+
+
+@dataclass
+class SpecialDay:
+    """Décrit un événement spécial impactant l'activité."""
+
+    date: date
+    event_type: str
+    expected_impact: Decimal
+
+
+@dataclass
+class WeeklySchedule:
+    """Planification hebdomadaire avec journées spéciales."""
+
+    special_days: list[SpecialDay] = field(default_factory=list)
+
+    def get_special_day(self, day: date) -> SpecialDay | None:
+        """Retourne l'événement spécial prévu pour une date."""
+        for sd in self.special_days:
+            if sd.date == day:
+                return sd
+        return None
+
+    def get_expected_impact(self, day: date) -> Decimal:
+        """Facteur multiplicatif de fréquentation pour la date donnée."""
+        sd = self.get_special_day(day)
+        return sd.expected_impact if sd else Decimal("1.0")

--- a/src/foodops_pro/ui/turn_report.py
+++ b/src/foodops_pro/ui/turn_report.py
@@ -1,0 +1,19 @@
+"""Génération de rapports de fin de tour."""
+
+from __future__ import annotations
+
+from ..core.production import ProductionPlan
+
+
+def render_turn_report(plan: ProductionPlan) -> list[str]:
+    """Construit les lignes de rapport pour le tour courant.
+
+    Met en avant l'impact des éventuels événements spéciaux.
+    """
+    lines: list[str] = []
+    if plan.special_day is not None:
+        sd = plan.special_day
+        lines.append(
+            f"📅 Journée spéciale: {sd.event_type} (impact attendu x{sd.expected_impact})"
+        )
+    return lines


### PR DESCRIPTION
## Summary
- add `WeeklySchedule` with `SpecialDay` entries to model special events
- adjust production capacity using special day impact modifiers
- display special day info in end-of-turn report

## Testing
- `ruff check src/foodops_pro/domain/schedule.py src/foodops_pro/core/production.py src/foodops_pro/ui/turn_report.py`
- `mypy --follow-imports=skip src/foodops_pro/domain/schedule.py src/foodops_pro/core/production.py src/foodops_pro/ui/turn_report.py`
- `pytest` *(fails: SyntaxError in src/foodops_pro/core/market.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c2c7d1108333ab4f4ba2ab07fda9