### PR TITLE
feat: add hygiene scheduling and inspections

### DIFF
--- a/src/foodops_pro/domain/__init__.py
+++ b/src/foodops_pro/domain/__init__.py
@@ -13,6 +13,7 @@ from .restaurant import Restaurant, RestaurantType
 from .employee import Employee, EmployeeContract, EmployeePosition
 from .scenario import Scenario, MarketSegment
 from .campaign import CampaignManager
+from .hygiene import HygieneTask, HygieneManager
 
 __all__ = [
     "Ingredient",
@@ -28,4 +29,6 @@ __all__ = [
     "Scenario",
     "MarketSegment",
     "CampaignManager",
+    "HygieneTask",
+    "HygieneManager",
 ]

--- a/src/foodops_pro/domain/hygiene.py
+++ b/src/foodops_pro/domain/hygiene.py
@@ -1,0 +1,83 @@
+"""Gestion de l'hygiène et des inspections pour FoodOps Pro."""
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import List, Optional
+import random
+
+
+@dataclass
+class HygieneTask:
+    """Tâche d'hygiène planifiée.
+
+    Attributes:
+        name: Description de la tâche.
+        cost: Coût de réalisation.
+        frequency: Fréquence en nombre de tours entre deux réalisations.
+        last_done: Tour de la dernière réalisation.
+    """
+
+    name: str
+    cost: Decimal
+    frequency: int
+    last_done: int = 0
+
+
+@dataclass
+class InspectionResult:
+    """Résultat d'une inspection sanitaire."""
+
+    turn: int
+    score: int
+    fine: Decimal = Decimal("0")
+
+
+class HygieneManager:
+    """Planifie les tâches d'hygiène et gère les inspections."""
+
+    def __init__(self, inspection_probability: float = 0.1) -> None:
+        self.tasks: List[HygieneTask] = []
+        self.inspections: List[InspectionResult] = []
+        self.inspection_probability = inspection_probability
+        self.attendance_modifier: Decimal = Decimal("1.0")
+        self._rng = random.Random()
+
+    # Planifier des tâches
+    def plan_task(self, task: HygieneTask) -> None:
+        self.tasks.append(task)
+
+    # Exécuter les tâches dues pour un tour et retourner le coût total
+    def run_tasks(self, current_turn: int) -> Decimal:
+        total_cost = Decimal("0")
+        for task in self.tasks:
+            if current_turn - task.last_done >= task.frequency:
+                total_cost += task.cost
+                task.last_done = current_turn
+        return total_cost
+
+    # Déclenchement potentiel d'une inspection
+    def maybe_inspect(self, current_turn: int) -> Optional[InspectionResult]:
+        if self._rng.random() > self.inspection_probability:
+            self.attendance_modifier = Decimal("1.0")
+            return None
+
+        overdue = sum(1 for t in self.tasks if current_turn - t.last_done > t.frequency)
+        score = max(0, 100 - overdue * 20)
+        fine = Decimal("0")
+        modifier = Decimal("1.0")
+        if score < 70:
+            modifier -= Decimal("0.10")
+            fine = Decimal("500")
+        if score < 50:
+            modifier -= Decimal("0.20")
+            fine = Decimal("1000")
+        self.attendance_modifier = modifier
+        result = InspectionResult(turn=current_turn, score=score, fine=fine)
+        self.inspections.append(result)
+        return result
+
+    def get_attendance_modifier(self) -> Decimal:
+        return self.attendance_modifier
+
+    def get_inspection_summary(self) -> List[InspectionResult]:
+        return list(self.inspections)

--- a/src/foodops_pro/io/persistence.py
+++ b/src/foodops_pro/io/persistence.py
@@ -263,6 +263,24 @@ class GameStatePersistence:
             "fixed_costs_monthly": float(restaurant.fixed_costs_monthly),
             "staffing_level": restaurant.staffing_level,
             "active_recipes": restaurant.active_recipes.copy(),
+            "hygiene": {
+                "tasks": [
+                    {
+                        "name": t.name,
+                        "cost": float(t.cost),
+                        "frequency": t.frequency,
+                    }
+                    for t in restaurant.hygiene_manager.tasks
+                ],
+                "inspections": [
+                    {
+                        "turn": i.turn,
+                        "score": i.score,
+                        "fine": float(i.fine),
+                    }
+                    for i in restaurant.hygiene_manager.inspections
+                ],
+            },
         }
 
     def update_turn_history(self, game_state: GameState, turn_results: Dict) -> None:

--- a/tests/test_hygiene.py
+++ b/tests/test_hygiene.py
@@ -1,0 +1,37 @@
+from decimal import Decimal
+
+from foodops_pro.domain.hygiene import HygieneManager, HygieneTask
+from foodops_pro.io.export import KPICalculator
+
+
+def test_hygiene_task_cost_frequency():
+    manager = HygieneManager()
+    manager.plan_task(HygieneTask("Nettoyage", Decimal("50"), 1))
+    assert manager.run_tasks(1) == Decimal("50")
+    assert manager.run_tasks(2) == Decimal("50")
+
+
+def test_inspection_penalty():
+    manager = HygieneManager(inspection_probability=1.0)
+    manager.plan_task(HygieneTask("Vérification", Decimal("10"), 1))
+    # Ne pas exécuter la tâche pour créer un retard
+    result = manager.maybe_inspect(2)
+    assert result is not None
+    assert result.score < 100
+    assert result.fine >= Decimal("500")
+    assert manager.get_attendance_modifier() < Decimal("1.0")
+
+
+def test_kpi_includes_hygiene_metrics():
+    restaurant_data = {
+        "id": "r1",
+        "hygiene": {
+            "inspections": [
+                {"turn": 1, "score": 80, "fine": 0},
+                {"turn": 2, "score": 60, "fine": 100},
+            ]
+        },
+    }
+    kpis = KPICalculator.calculate_restaurant_kpis(restaurant_data, [])
+    assert kpis["avg_hygiene_score"] == 70
+    assert kpis["total_hygiene_fines"] == Decimal("100")


### PR DESCRIPTION
## Summary
- add hygiene task and inspection management
- integrate hygiene data in persistence and export reports
- test hygiene scheduling, inspections and KPIs

## Testing
- `python -m pytest` *(fails: ImportError while loading conftest due to SyntaxError in src/foodops_pro/core/market.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a83c618b0c8333a5eec433cf165772